### PR TITLE
performance improvement in quantiles union

### DIFF
--- a/src/main/java/com/yahoo/sketches/quantiles/DoublesUnionImpl.java
+++ b/src/main/java/com/yahoo/sketches/quantiles/DoublesUnionImpl.java
@@ -120,7 +120,7 @@ final class DoublesUnionImpl extends DoublesUnionImplR {
 
   @Override
   public void update(final Memory mem) {
-    gadget_ = updateLogic(maxK_, gadget_, HeapUpdateDoublesSketch.heapifyInstance(mem));
+    gadget_ = updateLogic(maxK_, gadget_, DoublesSketch.wrap(mem));
   }
 
   @Override


### PR DESCRIPTION
It must be faster to wrap the input here, and, as far as I can tell, should not affect the result in any way