### PR TITLE
Fix for issue#296: InvalidPathException on Windows

### DIFF
--- a/src/main/java/org/apache/datasketches/Util.java
+++ b/src/main/java/org/apache/datasketches/Util.java
@@ -733,7 +733,7 @@ public final class Util {
     try {
       final URL url = Util.class.getClassLoader().getResource(shortFileName);
       final URI uri = url.toURI();
-      final String path = uri.getPath(); //decodes any special characters
+      final String path = uri.isAbsolute() ? Paths.get(uri).toAbsolutePath().toString() : uri.getPath();  //decodes any special characters
       return path;
     } catch (final NullPointerException | URISyntaxException e) {
       throw new SketchesArgumentException("Cannot find resource: " + shortFileName + LS + e);


### PR DESCRIPTION
After applying this fix, the test suite runs fine on Windows:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
[INFO] Tests run: 1387, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.847 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1387, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 32.481 s
[INFO] Finished at: 2020-01-26T21:50:51+10:00
[INFO] ------------------------------------------------------------------------
```