### PR TITLE
harmless bug fixed

### DIFF
--- a/src/main/java/org/apache/datasketches/cpc/CpcUnion.java
+++ b/src/main/java/org/apache/datasketches/cpc/CpcUnion.java
@@ -301,6 +301,7 @@ public class CpcUnion {
         if ((union.accumulator.getFlavor() == EMPTY) //lgtm [java/dereferenced-value-may-be-null]
             && (union.lgK == source.lgK)) {
           union.accumulator = source.copy();
+          break;
         }
         walkTableUpdatingSketch(union.accumulator, source.pairTable);
         // if the accumulator has graduated beyond sparse, switch union to a bitMatrix


### PR DESCRIPTION
If the union was empty, just copy the input and stop. There apparently was no stop by mistake, which is harmless, but wastes some time trying to insert the same coupons again.