### PR TITLE
Simplified, but did not eliminate the HLL union switch statement.

### DIFF
--- a/src/main/java/org/apache/datasketches/hll/AbstractCoupons.java
+++ b/src/main/java/org/apache/datasketches/hll/AbstractCoupons.java
@@ -102,12 +102,20 @@ abstract class AbstractCoupons extends HllSketchImpl {
   }
 
   @Override
+  boolean isOutOfOrder() {
+    return false;
+  }
+
+  @Override
   boolean isRebuildCurMinNumKxQFlag() {
     return false;
   }
 
   @Override
   void putEmptyFlag(final boolean empty) {} //no-op for coupons
+
+  @Override
+  void putOutOfOrder(final boolean outOfOrder) {} //no-op for coupons
 
   @Override
   void putRebuildCurMinNumKxQFlag(final boolean rebuild) {} //no-op for coupons

--- a/src/main/java/org/apache/datasketches/hll/AbstractHllArray.java
+++ b/src/main/java/org/apache/datasketches/hll/AbstractHllArray.java
@@ -87,7 +87,7 @@ abstract class AbstractHllArray extends HllSketchImpl {
 
   @Override
   double getEstimate() {
-    if (isOutOfOrderFlag()) {
+    if (isOutOfOrder()) {
       return getCompositeEstimate();
     }
     return getHipAccum();

--- a/src/main/java/org/apache/datasketches/hll/BaseHllSketch.java
+++ b/src/main/java/org/apache/datasketches/hll/BaseHllSketch.java
@@ -175,7 +175,7 @@ abstract class BaseHllSketch {
    * @return true if the current estimator is the non-HIP estimator, which is slightly less
    * accurate than the HIP estimator.
    */
-  abstract boolean isOutOfOrderFlag();
+  abstract boolean isOutOfOrder();
 
   /**
    * Returns true if the given Memory refers to the same underlying resource as this sketch.

--- a/src/main/java/org/apache/datasketches/hll/BaseHllSketch.java
+++ b/src/main/java/org/apache/datasketches/hll/BaseHllSketch.java
@@ -223,7 +223,11 @@ abstract class BaseHllSketch {
    * }</pre>
    *
    * <p>The sketch "wrapping" operation skips actual deserialization thus is quite fast. However,
-   * any attempt to update the derived HllSketch will result in a Read-only exception.
+   * any attempt to update the derived HllSketch will result in a Read-only exception.</p>
+   *
+   * <p>Note that in some cases, based on the state of the sketch, the compact form is
+   * indistiguishable from the updatable form.  In these cases the updatable form is returned
+   * and the compact flag bit will not be set.</p>
    * @return this sketch as a compact byte array.
    */
   public abstract byte[] toCompactByteArray();

--- a/src/main/java/org/apache/datasketches/hll/Conversions.java
+++ b/src/main/java/org/apache/datasketches/hll/Conversions.java
@@ -34,7 +34,7 @@ class Conversions {
   static final Hll4Array convertToHll4(final AbstractHllArray srcAbsHllArr) {
     final int lgConfigK = srcAbsHllArr.getLgConfigK();
     final Hll4Array hll4Array = new Hll4Array(lgConfigK);
-    hll4Array.putOutOfOrderFlag(srcAbsHllArr.isOutOfOrderFlag());
+    hll4Array.putOutOfOrder(srcAbsHllArr.isOutOfOrder());
 
     //1st pass: compute starting curMin and numAtCurMin:
     final int pair = curMinAndNum(srcAbsHllArr);
@@ -99,7 +99,7 @@ class Conversions {
   static final Hll6Array convertToHll6(final AbstractHllArray srcAbsHllArr) {
     final int lgConfigK = srcAbsHllArr.lgConfigK;
     final Hll6Array hll6Array = new Hll6Array(lgConfigK);
-    hll6Array.putOutOfOrderFlag(srcAbsHllArr.isOutOfOrderFlag());
+    hll6Array.putOutOfOrder(srcAbsHllArr.isOutOfOrder());
     int numZeros = 1 << lgConfigK;
     final PairIterator itr = srcAbsHllArr.iterator();
     while (itr.nextAll()) {
@@ -117,7 +117,7 @@ class Conversions {
   static final Hll8Array convertToHll8(final AbstractHllArray srcAbsHllArr) {
     final int lgConfigK = srcAbsHllArr.lgConfigK;
     final Hll8Array hll8Array = new Hll8Array(lgConfigK);
-    hll8Array.putOutOfOrderFlag(srcAbsHllArr.isOutOfOrderFlag());
+    hll8Array.putOutOfOrder(srcAbsHllArr.isOutOfOrder());
     int numZeros = 1 << lgConfigK;
     final PairIterator itr = srcAbsHllArr.iterator();
     while (itr.nextAll()) {

--- a/src/main/java/org/apache/datasketches/hll/CouponHashSet.java
+++ b/src/main/java/org/apache/datasketches/hll/CouponHashSet.java
@@ -79,7 +79,6 @@ class CouponHashSet extends CouponList {
     final CurMode curMode = extractCurMode(mem);
     final int memArrStart = (curMode == CurMode.LIST) ? LIST_INT_ARR_START : HASH_SET_INT_ARR_START;
     final CouponHashSet set = new CouponHashSet(lgConfigK, tgtHllType);
-    set.putOutOfOrderFlag(true);
     final boolean memIsCompact = extractCompactFlag(mem);
     final int couponCount = extractHashSetCount(mem);
     int lgCouponArrInts = extractLgArr(mem);

--- a/src/main/java/org/apache/datasketches/hll/DirectCouponList.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectCouponList.java
@@ -28,13 +28,11 @@ import static org.apache.datasketches.hll.PreambleUtil.HASH_SET_PREINTS;
 import static org.apache.datasketches.hll.PreambleUtil.HLL_PREINTS;
 import static org.apache.datasketches.hll.PreambleUtil.LIST_INT_ARR_START;
 import static org.apache.datasketches.hll.PreambleUtil.LIST_PREINTS;
-import static org.apache.datasketches.hll.PreambleUtil.OUT_OF_ORDER_FLAG_MASK;
 import static org.apache.datasketches.hll.PreambleUtil.computeLgArr;
 import static org.apache.datasketches.hll.PreambleUtil.extractCompactFlag;
 import static org.apache.datasketches.hll.PreambleUtil.extractInt;
 import static org.apache.datasketches.hll.PreambleUtil.extractLgArr;
 import static org.apache.datasketches.hll.PreambleUtil.extractListCount;
-import static org.apache.datasketches.hll.PreambleUtil.extractOooFlag;
 import static org.apache.datasketches.hll.PreambleUtil.insertCurMin;
 import static org.apache.datasketches.hll.PreambleUtil.insertCurMode;
 import static org.apache.datasketches.hll.PreambleUtil.insertEmptyFlag;
@@ -47,7 +45,6 @@ import static org.apache.datasketches.hll.PreambleUtil.insertLgK;
 import static org.apache.datasketches.hll.PreambleUtil.insertListCount;
 import static org.apache.datasketches.hll.PreambleUtil.insertModes;
 import static org.apache.datasketches.hll.PreambleUtil.insertNumAtCurMin;
-import static org.apache.datasketches.hll.PreambleUtil.insertOooFlag;
 import static org.apache.datasketches.hll.PreambleUtil.insertPreInts;
 import static org.apache.datasketches.hll.PreambleUtil.insertSerVer;
 
@@ -207,11 +204,6 @@ class DirectCouponList extends AbstractCoupons {
   }
 
   @Override
-  boolean isOutOfOrderFlag() {
-    return extractOooFlag(mem);
-  }
-
-  @Override
   boolean isSameResource(final Memory mem) {
     return this.mem.isSameResource(mem);
   }
@@ -232,12 +224,6 @@ class DirectCouponList extends AbstractCoupons {
       if (pair == 0) { continue; }
       that.couponUpdate(pair);
     }
-  }
-
-  @Override //not used on the direct side
-  void putOutOfOrderFlag(final boolean oooFlag) {
-    assert wmem != null;
-    insertOooFlag(wmem, oooFlag);
   }
 
   @Override
@@ -269,7 +255,6 @@ class DirectCouponList extends AbstractCoupons {
     insertPreInts(wmem, HASH_SET_PREINTS);
     //SerVer, FamID, LgK  should be OK
     insertLgArr(wmem, LG_INIT_SET_SIZE);
-    insertFlags(wmem, (byte) OUT_OF_ORDER_FLAG_MASK); //set oooFlag
     insertCurMin(wmem, 0); //was list count
     insertCurMode(wmem, CurMode.SET);
     //tgtHllType should already be ok

--- a/src/main/java/org/apache/datasketches/hll/DirectHllArray.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectHllArray.java
@@ -179,7 +179,7 @@ abstract class DirectHllArray extends AbstractHllArray {
   }
 
   @Override
-  boolean isOutOfOrderFlag() {
+  boolean isOutOfOrder() {
     return extractOooFlag(mem);
   }
 
@@ -248,7 +248,7 @@ abstract class DirectHllArray extends AbstractHllArray {
   }
 
   @Override //not used on the direct side
-  void putOutOfOrderFlag(final boolean oooFlag) {
+  void putOutOfOrder(final boolean oooFlag) {
     checkReadOnly(wmem);
     insertOooFlag(wmem, oooFlag);
   }

--- a/src/main/java/org/apache/datasketches/hll/HllArray.java
+++ b/src/main/java/org/apache/datasketches/hll/HllArray.java
@@ -71,7 +71,7 @@ abstract class HllArray extends AbstractHllArray {
    */
   HllArray(final HllArray that) {
     super(that.getLgConfigK(), that.getTgtHllType(), CurMode.HLL);
-    oooFlag = that.isOutOfOrderFlag();
+    oooFlag = that.isOutOfOrder();
     rebuildCurMinNumKxQ = that.isRebuildCurMinNumKxQFlag();
     curMin = that.getCurMin();
     numAtCurMin = that.getNumAtCurMin();
@@ -180,7 +180,7 @@ abstract class HllArray extends AbstractHllArray {
   }
 
   @Override
-  boolean isOutOfOrderFlag() {
+  boolean isOutOfOrder() {
     return oooFlag;
   }
 
@@ -228,7 +228,7 @@ abstract class HllArray extends AbstractHllArray {
   }
 
   @Override
-  void putOutOfOrderFlag(final boolean oooFlag) {
+  void putOutOfOrder(final boolean oooFlag) {
     this.oooFlag = oooFlag;
   }
 
@@ -255,7 +255,7 @@ abstract class HllArray extends AbstractHllArray {
 
   //used by heapify by all Heap HLL
   static final void extractCommonHll(final Memory srcMem, final HllArray hllArray) {
-    hllArray.putOutOfOrderFlag(extractOooFlag(srcMem));
+    hllArray.putOutOfOrder(extractOooFlag(srcMem));
     hllArray.putEmptyFlag(extractEmptyFlag(srcMem));
     hllArray.putCurMin(extractCurMin(srcMem));
     hllArray.putHipAccum(extractHipAccum(srcMem));

--- a/src/main/java/org/apache/datasketches/hll/HllEstimators.java
+++ b/src/main/java/org/apache/datasketches/hll/HllEstimators.java
@@ -52,7 +52,7 @@ class HllEstimators {
         (absHllArr.getCurMin() == 0) ? configK - absHllArr.getNumAtCurMin() : configK;
     final double estimate;
     final double rseFactor;
-    final boolean oooFlag = absHllArr.isOutOfOrderFlag();
+    final boolean oooFlag = absHllArr.isOutOfOrder();
     if (oooFlag) {
       estimate = absHllArr.getCompositeEstimate();
       rseFactor = HLL_NON_HIP_RSE_FACTOR;
@@ -71,7 +71,7 @@ class HllEstimators {
     final int configK = 1 << lgConfigK;
     final double estimate;
     final double rseFactor;
-    final boolean oooFlag = absHllArr.isOutOfOrderFlag();
+    final boolean oooFlag = absHllArr.isOutOfOrder();
     if (oooFlag) {
       estimate = absHllArr.getCompositeEstimate();
       rseFactor = HLL_NON_HIP_RSE_FACTOR;

--- a/src/main/java/org/apache/datasketches/hll/HllSketch.java
+++ b/src/main/java/org/apache/datasketches/hll/HllSketch.java
@@ -422,7 +422,7 @@ public class HllSketch extends BaseHllSketch {
         sb.append("  HipAccum       : ").append(absHll.getHipAccum()).append(LS);
         sb.append("  KxQ0           : ").append(absHll.getKxQ0()).append(LS);
         sb.append("  KxQ1           : ").append(absHll.getKxQ1()).append(LS);
-        sb.append("  Rebuild HIP Flg: ").append(absHll.isRebuildCurMinNumKxQFlag()).append(LS);
+        sb.append("  Rebuild KxQ Flg: ").append(absHll.isRebuildCurMinNumKxQFlag()).append(LS);
       } else {
         sb.append("  Coupon Count   : ")
           .append(((AbstractCoupons)hllSketchImpl).getCouponCount()).append(LS);

--- a/src/main/java/org/apache/datasketches/hll/HllSketch.java
+++ b/src/main/java/org/apache/datasketches/hll/HllSketch.java
@@ -368,8 +368,8 @@ public class HllSketch extends BaseHllSketch {
   }
 
   @Override
-  boolean isOutOfOrderFlag() {
-    return hllSketchImpl.isOutOfOrderFlag();
+  boolean isOutOfOrder() {
+    return hllSketchImpl.isOutOfOrder();
   }
 
   @Override
@@ -381,8 +381,9 @@ public class HllSketch extends BaseHllSketch {
     hllSketchImpl.mergeTo(that);
   }
 
-  void putOutOfOrderFlag(final boolean oooFlag) {
-    hllSketchImpl.putOutOfOrderFlag(oooFlag);
+  HllSketch putOutOfOrderFlag(final boolean oooFlag) {
+    hllSketchImpl.putOutOfOrder(oooFlag);
+    return this;
   }
 
   @Override
@@ -413,7 +414,7 @@ public class HllSketch extends BaseHllSketch {
       sb.append("  LB             : ").append(getLowerBound(1)).append(LS);
       sb.append("  Estimate       : ").append(getEstimate()).append(LS);
       sb.append("  UB             : ").append(getUpperBound(1)).append(LS);
-      sb.append("  OutOfOrder Flag: ").append(isOutOfOrderFlag()).append(LS);
+      sb.append("  OutOfOrder Flag: ").append(isOutOfOrder()).append(LS);
       if (getCurMode() == CurMode.HLL) {
         final AbstractHllArray absHll = (AbstractHllArray) hllSketchImpl;
         sb.append("  CurMin         : ").append(absHll.getCurMin()).append(LS);

--- a/src/main/java/org/apache/datasketches/hll/HllSketchImpl.java
+++ b/src/main/java/org/apache/datasketches/hll/HllSketchImpl.java
@@ -96,7 +96,7 @@ abstract class HllSketchImpl {
 
   abstract boolean isOffHeap();
 
-  abstract boolean isOutOfOrderFlag();
+  abstract boolean isOutOfOrder();
 
   abstract boolean isRebuildCurMinNumKxQFlag();
 
@@ -108,7 +108,7 @@ abstract class HllSketchImpl {
 
   abstract void putEmptyFlag(boolean empty);
 
-  abstract void putOutOfOrderFlag(boolean oooFlag);
+  abstract void putOutOfOrder(boolean oooFlag);
 
   abstract void putRebuildCurMinNumKxQFlag(boolean rebuild);
 

--- a/src/main/java/org/apache/datasketches/hll/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/hll/PreambleUtil.java
@@ -173,6 +173,7 @@ final class PreambleUtil {
     final boolean oooFlag = (flags & OUT_OF_ORDER_FLAG_MASK) > 0;
     final boolean readOnly = (flags & READ_ONLY_FLAG_MASK) > 0;
     final boolean empty = (flags & EMPTY_FLAG_MASK) > 0;
+    final boolean rebuildKxQ = (flags & REBUILD_CURMIN_NUM_KXQ_MASK) > 0;
 
     final int hllCurMin = mem.getByte(HLL_CUR_MIN_BYTE);
     final int listCount = hllCurMin;
@@ -223,6 +224,7 @@ final class PreambleUtil {
     sb.append("  EMPTY                       : ").append(empty).append(LS);
     sb.append("  COMPACT                     : ").append(compact).append(LS);
     sb.append("  OUT_OF_ORDER                : ").append(oooFlag).append(LS);
+    sb.append("  REBUILD_KXQ                 : ").append(rebuildKxQ).append(LS);
     //expand byte 6: ListCount, CurMin
     if (curMode == CurMode.LIST) {
       sb.append("Byte 6: List Count/CurMin     : ").append(listCount).append(LS);
@@ -231,7 +233,7 @@ final class PreambleUtil {
       sb.append("Byte 6: (not used)            : ").append(LS);
     }
     if (curMode == CurMode.HLL) {
-      sb.append("Byte 6: Cur Min               : ").append(curMinCount).append(LS);
+      sb.append("Byte 6: Cur Min               : ").append(hllCurMin).append(LS);
     }
     final String modes = curMode.toString() + ", " + tgtHllType.toString();
     sb.append("Byte 7: Mode                  : ").append(modes).append(LS);

--- a/src/main/java/org/apache/datasketches/hll/ToByteArrayImpl.java
+++ b/src/main/java/org/apache/datasketches/hll/ToByteArrayImpl.java
@@ -93,7 +93,7 @@ class ToByteArrayImpl {
     insertLgK(tgtWmem, srcImpl.getLgConfigK());
     insertEmptyFlag(tgtWmem, srcImpl.isEmpty());
     insertCompactFlag(tgtWmem, compact);
-    insertOooFlag(tgtWmem, srcImpl.isOutOfOrderFlag());
+    insertOooFlag(tgtWmem, srcImpl.isOutOfOrder());
     insertCurMin(tgtWmem, srcImpl.getCurMin());
     insertCurMode(tgtWmem, srcImpl.getCurMode());
     insertTgtHllType(tgtWmem, srcImpl.getTgtHllType());
@@ -245,7 +245,7 @@ class ToByteArrayImpl {
     insertLgK(wmem, impl.getLgConfigK());
     insertLgArr(wmem, impl.getLgCouponArrInts());
     insertEmptyFlag(wmem, impl.isEmpty());
-    insertOooFlag(wmem, impl.isOutOfOrderFlag());
+    insertOooFlag(wmem, impl.isOutOfOrder());
     insertCurMode(wmem, impl.getCurMode());
     insertTgtHllType(wmem, impl.getTgtHllType());
   }

--- a/src/test/java/org/apache/datasketches/hll/DirectUnionTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectUnionTest.java
@@ -220,9 +220,9 @@ public class DirectUnionTest {
     double controlEst = control.getEstimate();
     double controlUb = control.getUpperBound(2);
     double controlLb = control.getLowerBound(2);
-    String h1ooo = h1.isOutOfOrderFlag() ? "T" : "F";
-    String h2ooo = h2.isOutOfOrderFlag() ? "T" : "F";
-    String resultooo = result.isOutOfOrderFlag() ?  "T" : "F";
+    String h1ooo = h1.isOutOfOrder() ? "T" : "F";
+    String h2ooo = h2.isOutOfOrder() ? "T" : "F";
+    String resultooo = result.isOutOfOrder() ?  "T" : "F";
     String row = String.format(dataFmt,
         n1, n2, tot,
         lgMaxK, lgK1, lgK2, lgKR,

--- a/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
@@ -101,7 +101,7 @@ public class UnionCaseTest {
     double estU = union.getEstimate();
     double err = Math.abs((estU / totalU) - 1.0);
     int gdtLgK = union.getLgConfigK();
-    boolean uooof = union.isOutOfOrderFlag();
+    boolean uooof = union.isOutOfOrder();
     double rseFactor = (uooof) ? HLL_NON_HIP_RSE_FACTOR : HLL_HIP_RSE_FACTOR;
     double rse = (rseFactor * 3) / Math.sqrt(1 << gdtLgK); //99.7% conf
 
@@ -115,8 +115,8 @@ public class UnionCaseTest {
     String gdtMem = Boolean.toString(union.isMemory());
     String srcMode = source.getCurMode().toString();
     String gdtMode = union.getCurMode().toString();
-    String srcOoof = Boolean.toString(source.isOutOfOrderFlag());
-    String gdtOoof = Boolean.toString(union.isOutOfOrderFlag());
+    String srcOoof = Boolean.toString(source.isOutOfOrder());
+    String gdtOoof = Boolean.toString(union.isOutOfOrder());
     printf(hfmt, caseNumStr, srcLgKStr, gdtLgKStr, srcType, gdtType, srcMem, gdtMem,
         srcMode, gdtMode, srcOoof, gdtOoof);
     assertTrue(err < rse, "Err: " + err + ", RSE: " + rse);
@@ -192,8 +192,8 @@ public class UnionCaseTest {
     println(u.toString());
     assertEquals(u.getCurMode(), LIST);
     assertEquals(u.getLgConfigK(), 12);
-    assertFalse(u.isOutOfOrderFlag());
-    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrderFlag(), 3.0);
+    assertFalse(u.isOutOfOrder());
+    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrder(), 3.0);
     println("ErrToll: " + err);
     assertEquals(u.getEstimate(), sum, err);
   }
@@ -214,8 +214,8 @@ public class UnionCaseTest {
     println(u.toString());
     assertEquals(u.getCurMode(), SET);
     assertEquals(u.getLgConfigK(), 12);
-    assertTrue(u.isOutOfOrderFlag());
-    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrderFlag(), 3.0);
+    assertFalse(u.isOutOfOrder());
+    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrder(), 3.0);
     println("ErrToll: " + err);
     assertEquals(u.getEstimate(), sum, err);
   }
@@ -236,8 +236,8 @@ public class UnionCaseTest {
     println(u.toString());
     assertEquals(u.getCurMode(), SET);
     assertEquals(u.getLgConfigK(), 12);
-    assertTrue(u.isOutOfOrderFlag());
-    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrderFlag(), 3.0);
+    assertFalse(u.isOutOfOrder());
+    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrder(), 3.0);
     println("ErrToll: " + err);
     assertEquals(u.getEstimate(), sum, err);
   }
@@ -258,8 +258,8 @@ public class UnionCaseTest {
     println(u.toString());
     assertEquals(u.getCurMode(), SET);
     assertEquals(u.getLgConfigK(), 12);
-    assertTrue(u.isOutOfOrderFlag());
-    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrderFlag(), 3.0);
+    assertFalse(u.isOutOfOrder());
+    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrder(), 3.0);
     println("ErrToll: " + err);
     assertEquals(u.getEstimate(), sum, err);
   }
@@ -280,8 +280,8 @@ public class UnionCaseTest {
     println(u.toString());
     assertEquals(u.getCurMode(), LIST);
     assertEquals(u.getLgConfigK(), 12);
-    assertFalse(u.isOutOfOrderFlag());
-    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrderFlag(), 3.0);
+    assertFalse(u.isOutOfOrder());
+    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrder(), 3.0);
     println("ErrToll: " + err);
     assertEquals(u.getEstimate(), sum, err);
   }
@@ -302,8 +302,8 @@ public class UnionCaseTest {
     println(u.toString());
     assertEquals(u.getCurMode(), SET);
     assertEquals(u.getLgConfigK(), 12);
-    assertTrue(u.isOutOfOrderFlag());
-    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrderFlag(), 3.0);
+    assertFalse(u.isOutOfOrder());
+    double err = sum * errorFactor(u.getLgConfigK(), u.isOutOfOrder(), 3.0);
     println("ErrToll: " + err);
     assertEquals(u.getEstimate(), sum, err);
   }

--- a/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
@@ -437,7 +437,7 @@ public class UnionCaseTest {
    * @param o value to print
    */
   static void print(Object o) {
-    //System.out.print(o.toString()); //disable here
+    System.out.print(o.toString()); //disable here
   }
 
   /**
@@ -445,7 +445,7 @@ public class UnionCaseTest {
    * @param args arguments
    */
   static void printf(String fmt, Object...args) {
-    //System.out.printf(fmt, args); //disable here
+    System.out.printf(fmt, args); //disable here
   }
 
 }

--- a/src/test/java/org/apache/datasketches/hll/UnionTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionTest.java
@@ -219,9 +219,9 @@ public class UnionTest {
     double controlEst = control.getEstimate();
     double controlUb = control.getUpperBound(2);
     double controlLb = control.getLowerBound(2);
-    String h1ooo = h1.isOutOfOrderFlag() ? "T" : "F";
-    String h2ooo = h2.isOutOfOrderFlag() ? "T" : "F";
-    String resultooo = result.isOutOfOrderFlag() ?  "T" : "F";
+    String h1ooo = h1.isOutOfOrder() ? "T" : "F";
+    String h2ooo = h2.isOutOfOrder() ? "T" : "F";
+    String resultooo = result.isOutOfOrder() ?  "T" : "F";
     String row = String.format(dataFmt,
         n1, n2, tot,
         lgMaxK, lgK1, lgK2, lgKR,


### PR DESCRIPTION
Removed the Out-of-order flag in the coupon classes.  Corrected tests
that assumed the prior assumptions of OOO for sets.