### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@
 
 language: java
 
-sudo: false # faster builds
-
 dist: trusty
 
 jdk:


### PR DESCRIPTION
[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)