### PR TITLE
Remove extraneous </p> in Javadoc.

### DIFF
--- a/src/main/java/org/apache/datasketches/theta/Union.java
+++ b/src/main/java/org/apache/datasketches/theta/Union.java
@@ -121,7 +121,7 @@ public abstract class Union extends SetOperation {
    *
    * <p>Note: this is not a Sketch Union operation. This treats the given string as a data item.</p>
    *
-   * @param datum The given String.</p>
+   * @param datum The given String.
    */
   public abstract void update(String datum);
 


### PR DESCRIPTION
Accidentally introduced in master 3 days ago.  This does not appear in our last 1.3.0 release.